### PR TITLE
fix:  eslint-plugin-import가 적용되지 않는 버그 수정

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,9 @@
 import js from "@eslint/js";
 import pluginImport from "eslint-plugin-import";
 import globals from "globals";
-import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default [
   {
-    extends: ["plugin:import/recommended"],
     files: ["**/*.{js,mjs,cjs}"],
     languageOptions: {
       globals: globals.node,
@@ -28,12 +26,6 @@ export default defineConfig([
             "object",
             "type",
           ],
-          pathGroups: [
-            {
-              pattern: "@/**",
-              group: "internal",
-            },
-          ],
           "newlines-between": "always",
           alphabetize: {
             order: "asc",
@@ -43,4 +35,4 @@ export default defineConfig([
       ],
     },
   },
-]);
+];

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,5 @@
-import express from "express";
 import dotenv from "dotenv";
+import express from "express";
 
 import { supabase } from "./services/supabaseClient.js";
 


### PR DESCRIPTION
### ✨ 이슈 번호

- #8 

### 📌 설명

eslint.config.mjs 파일에서 import/order 규칙이 동작하지 않는 문제를 해결하기 위해 eslint 설정 파일을 eslint.config.js로 변경한 Pull request

### 📃 작업 사항

- [x] eslint.config.mjs 파일 eslint.config.js로 변경 및 defineConfig 삭제

### 💡 참고 사항

eslint.config.mjs 파일에서 import/order 규칙이 동작하지 않는 문제를 eslint 설정 파일을 eslint.config.js로 변경하여 해결했습니다.

### 💭 리뷰 사항 반영 (필수)

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
