### PR TITLE
feat: 라디오 채널 목록 조회 API 구현

### DIFF
--- a/src/controllers/radioController.js
+++ b/src/controllers/radioController.js
@@ -1,0 +1,11 @@
+import { findRadioChannelList } from "../services/radioChannelService.js";
+
+export const getRadioChannelList = async (_req, res, next) => {
+  try {
+    const channels = await findRadioChannelList();
+
+    return res.status(200).json(channels);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/radio-channels/allRadioList.js
+++ b/src/routes/radio-channels/allRadioList.js
@@ -1,0 +1,9 @@
+import express from "express";
+
+import { getRadioChannelList } from "../../controllers/radioController.js";
+
+const router = express.Router();
+
+router.get("", getRadioChannelList);
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import express from "express";
 
 import { errorHandler } from "./middlewares/errorHandler.js";
+import radioRoutes from "./routes/radio-channels/allRadioList.js";
 import userRoutes from "./routes/users/[userId].js";
 
 dotenv.config();
@@ -11,6 +12,7 @@ const app = express();
 app.use(express.json());
 
 app.use("/users", userRoutes);
+app.use("/radio-channels", radioRoutes);
 
 app.use(errorHandler);
 

--- a/src/services/radioChannelService.js
+++ b/src/services/radioChannelService.js
@@ -1,0 +1,30 @@
+import { supabase } from "./supabaseClient.js";
+import { toCamelCase } from "../utils/caseConverter.js";
+
+export const findRadioChannelList = async () => {
+  const { data, error } = await supabase.from("channels").select(
+    `
+    id,
+    station,
+    name,
+    area_id,
+    url,
+    is_api_exposed,
+    logo_url,
+    created_at
+    `
+  );
+
+  if (error) {
+    console.error("Supabase error:", error);
+    throw new Error("Supabase query failed");
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const camelData = toCamelCase(data);
+
+  return camelData;
+};


### PR DESCRIPTION
### ✨ 이슈 번호 

- #13 

### 📌 설명

- 라디오 채널 목록 조회 API를 구현에 관한 PR입니다.
- 클라이언트에서 라디오 채널 리스트를 출력하는 API 입니다.
- 모든 채널 정보를 배열 형태로 반환합니다.
- 각 채널에는 방송사, 채널 명, 지역 코드, URL, 로고 이미지, API 노출 여부 등의 정보가 포함됩니다.

### 📃 작업 사항 

라디오 채널 목록 조회 API를 구현한다.
- [X]  라디오 채널 정보를 DB 데이터에서 전체 조회한다.
- [X] 조회된 채널 리스트를 배열 형태 응답으로 반환한다.

**요청 실패 시:**
- [X] 잘못된 요청일 시 `400` 상태 코드와 “올바르지 않은 형식입니다” 응답을 반환한다.
- [X] 내부 서버에 오류가 발생했을 시 `500`상태 코드와 “서버에서 요청을 처리할 수 없습니다 ” 응답을 반환한다.

### 💡 참고 사항
![image](https://github.com/user-attachments/assets/7cc3513e-0be7-4420-8e06-319b5034473e)

### 💭 리뷰 사항 반영 

### ✅ Pull Request 체크 사항

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.
