### PR TITLE
feat: 사용자 설정 변경 API 구현

### DIFF
--- a/src/controllers/userSettingController.js
+++ b/src/controllers/userSettingController.js
@@ -1,0 +1,47 @@
+import { findUserById } from "../services/userService.js";
+import { updateUserSettingById } from "../services/userSettingService.js";
+import { stringToSnakeCase } from "../utils/caseConverter.js";
+
+export const updateUserSettings = async (req, res, next) => {
+  try {
+    const { userId } = req.params;
+    const reqSettingFields = ["isAdDetect", "isReturnChannel"];
+    const settingFields = reqSettingFields.map((key) => [
+      key,
+      stringToSnakeCase(key),
+    ]);
+
+    const updateFields = {};
+    for (const [reqKey, dbKey] of settingFields) {
+      const value = req.body?.[reqKey];
+      if (value !== undefined) {
+        if (typeof value !== "boolean") {
+          return res.status(400).json({
+            status: 400,
+            error: "올바르지 않은 형식입니다.",
+          });
+        }
+        updateFields[dbKey] = value;
+      }
+    }
+
+    if (Object.keys(updateFields).length === 0) {
+      return res.status(400).json({
+        status: 400,
+        error: "올바르지 않은 형식입니다.",
+      });
+    }
+
+    const user = await findUserById(Number(userId));
+    if (!user) {
+      return res
+        .status(404)
+        .json({ status: 404, error: "사용자를 찾을 수 없습니다." });
+    }
+
+    const message = await updateUserSettingById(Number(userId), updateFields);
+    res.status(200).json(message);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/users/[userId].js
+++ b/src/routes/users/[userId].js
@@ -7,11 +7,13 @@ import {
   getUserById,
   updateInterestChannels,
 } from "../../controllers/userController.js";
+import { updateUserSettings } from "../../controllers/userSettingController.js";
 import { validateUserId } from "../../validators/userValidator.js";
 
 const router = express.Router();
 
 router.get("/:userId", validateUserId, getUserById);
+
 router.get(
   "/:userId/interest-channels",
   validateUserId,
@@ -32,5 +34,7 @@ router.delete(
   validateUserId,
   deleteInterestChannel
 );
+
+router.put("/:userId/settings", validateUserId, updateUserSettings);
 
 export default router;

--- a/src/routes/users/[userId].js
+++ b/src/routes/users/[userId].js
@@ -13,6 +13,7 @@ import { validateUserId } from "../../validators/userValidator.js";
 const router = express.Router();
 
 router.get("/:userId", validateUserId, getUserById);
+router.put("/:userId/settings", validateUserId, updateUserSettings);
 
 router.get(
   "/:userId/interest-channels",
@@ -34,7 +35,5 @@ router.delete(
   validateUserId,
   deleteInterestChannel
 );
-
-router.put("/:userId/settings", validateUserId, updateUserSettings);
 
 export default router;

--- a/src/services/userSettingService.js
+++ b/src/services/userSettingService.js
@@ -1,0 +1,18 @@
+import { supabase } from "./supabaseClient.js";
+
+export const updateUserSettingById = async (userId, updateFields) => {
+  const { error } = await supabase
+    .from("users")
+    .update(updateFields)
+    .eq("id", userId);
+
+  if (error) {
+    console.error("Supabase update error:", error);
+    throw new Error("Supabase update failed");
+  }
+
+  return {
+    status: 200,
+    message: "사용자 설정이 성공적으로 변경되었습니다.",
+  };
+};


### PR DESCRIPTION
### ✨ 이슈 번호

- #22 

### 📌 설명

- 사용자 설정 변경 API를 구현하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x]  userId를 path parameter에서 추출
- [x]  body에서 isAdDetect, isReturnChannel 중 전달된 필드만 추출하여 사용자 설정에 반영
- [x] 성공 시
  - [x]  200 OK 상태 코드와 함께 “사용자 설정이 성공적으로 변경되었습니다."메시지를 반환
- [x] 실패 시
  - [x]  잘못된 요청일 경우 `400` 상태 코드와 "올바르지 않은 형식입니다."응답을 반환
  - [x]  존재하지 않는 사용자의 경우 `404`상태 코드와 “존재하지 않는 사용자” 응답을 반환
  - [x]  내부 서버 오류 시 `500` 상태 코드와 "서버에서 요청을 처리할 수 없습니다."응답을 반환

### 💭 리뷰 사항 반영
- [x] 사용자 관련 라우터 위치 변경

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
