### PR TITLE
refactor: HTTP 상태 코드 및 응답 메시지 상수화

### DIFF
--- a/src/constants/httpStatus.js
+++ b/src/constants/httpStatus.js
@@ -1,0 +1,7 @@
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  BAD_REQUEST: 400,
+  NOT_FOUND: 404,
+  INTERNAL_SERVER_ERROR: 500,
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,2 @@
+export { HTTP_STATUS } from "./httpStatus.js";
+export { MESSAGES } from "./messages.js";

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -1,0 +1,22 @@
+export const MESSAGES = {
+  SUCCESS: {
+    AD_REPORT_CREATED: "광고 제보 등록 성공했습니다.",
+    INTEREST_CHANNEL_CREATED: "관심 채널 등록 성공했습니다.",
+    INTEREST_CHANNELS_UPDATED: "관심 채널 갱신에 성공했습니다.",
+    INTEREST_CHANNEL_DELETED: "관심 채널 삭제 성공했습니다.",
+    USER_CREATED: "사용자 등록 성공했습니다.",
+    USER_SETTINGS_UPDATED: "사용자 설정 갱신 성공했습니다.",
+  },
+  ERROR: {
+    INVALID_FORMAT: "올바르지 않은 형식입니다.",
+    USER_NOT_FOUND: "사용자를 찾을 수 없습니다.",
+    CHANNEL_NOT_FOUND: "채널을 찾을 수 없습니다.",
+    INTEREST_CHANNEL_EXISTS: "이미 등록된 관심 채널입니다.",
+    INTEREST_CHANNEL_NOT_FOUND: "등록된 관심 채널이 없습니다.",
+    INVALID_CHANNELS: "존재하지 않는 채널이 포함되어 있습니다.",
+    SUPABASE_QUERY_FAILED: "Supabase query failed",
+    SUPABASE_INSERT_FAILED: "Supabase insert failed",
+    SUPABASE_DELETE_FAILED: "Supabase delete failed",
+    SUPABASE_UPDATE_FAILED: "Supabase update failed",
+  },
+};

--- a/src/controllers/ad-keywords/adKeywordController.js
+++ b/src/controllers/ad-keywords/adKeywordController.js
@@ -1,10 +1,11 @@
+import { HTTP_STATUS } from "../../constants/index.js";
 import { getAdKeywordListService } from "../../services/ad-keywords/adKeywordService.js";
 
 export const getAdKeywordList = async (_req, res, next) => {
   try {
     const adKeywords = await getAdKeywordListService();
 
-    return res.status(200).json(adKeywords);
+    return res.status(HTTP_STATUS.OK).json(adKeywords);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/radio-channels/radioChannelController.js
+++ b/src/controllers/radio-channels/radioChannelController.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import {
   getRadioChannelListService,
   getRadioChannelByIdService,
@@ -7,7 +8,7 @@ export const getRadioChannelList = async (_req, res, next) => {
   try {
     const channels = await getRadioChannelListService();
 
-    return res.status(200).json(channels);
+    return res.status(HTTP_STATUS.OK).json(channels);
   } catch (error) {
     next(error);
   }
@@ -19,12 +20,13 @@ export const getRadioChannelById = async (req, res, next) => {
     const channel = await getRadioChannelByIdService(Number(channelId));
 
     if (!channel) {
-      return res
-        .status(404)
-        .json({ status: 404, error: "채널을 찾을 수 없습니다." });
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
+        status: HTTP_STATUS.NOT_FOUND,
+        error: MESSAGES.ERROR.CHANNEL_NOT_FOUND,
+      });
     }
 
-    res.status(200).json(channel);
+    res.status(HTTP_STATUS.OK).json(channel);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/reports/reportController.js
+++ b/src/controllers/reports/reportController.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS } from "../../constants/index.js";
 import { createAdReportService } from "../../services/reports/reportService.js";
 
 export const createAdReport = async (req, res, next) => {
@@ -11,7 +12,7 @@ export const createAdReport = async (req, res, next) => {
       channelId,
     });
 
-    res.status(201).json(result);
+    res.status(HTTP_STATUS.CREATED).json(result);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/users/userController.js
+++ b/src/controllers/users/userController.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import {
   createUserService,
   getUserByIdService,
@@ -17,9 +18,9 @@ export const createUser = async (req, res, next) => {
       const value = req.body?.[reqKey];
       if (value !== undefined) {
         if (typeof value !== "boolean") {
-          return res.status(400).json({
-            status: 400,
-            error: "올바르지 않은 형식입니다.",
+          return res.status(HTTP_STATUS.BAD_REQUEST).json({
+            status: HTTP_STATUS.BAD_REQUEST,
+            error: MESSAGES.ERROR.INVALID_FORMAT,
           });
         }
         insertFields[dbKey] = value;
@@ -27,7 +28,7 @@ export const createUser = async (req, res, next) => {
     }
 
     const message = await createUserService(insertFields);
-    res.status(201).json(message);
+    res.status(HTTP_STATUS.CREATED).json(message);
   } catch (error) {
     next(error);
   }
@@ -39,12 +40,13 @@ export const getUserById = async (req, res, next) => {
     const user = await getUserByIdService(Number(userId));
 
     if (!user) {
-      return res
-        .status(404)
-        .json({ status: 404, error: "사용자를 찾을 수 없습니다." });
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
+        status: HTTP_STATUS.NOT_FOUND,
+        error: MESSAGES.ERROR.USER_NOT_FOUND,
+      });
     }
 
-    res.status(200).json(user);
+    res.status(HTTP_STATUS.OK).json(user);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/users/userInterestChannelController.js
+++ b/src/controllers/users/userInterestChannelController.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import {
   createInterestChannelService,
   getInterestChannelByIdService,
@@ -11,9 +12,9 @@ export const createInterestChannel = async (req, res, next) => {
     const { channelId } = req.body;
 
     if (typeof channelId !== "number") {
-      return res.status(400).json({
-        status: 400,
-        error: "올바르지 않은 형식입니다.",
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
+        status: HTTP_STATUS.BAD_REQUEST,
+        error: MESSAGES.ERROR.INVALID_FORMAT,
       });
     }
 
@@ -22,7 +23,7 @@ export const createInterestChannel = async (req, res, next) => {
       Number(channelId)
     );
 
-    res.status(200).json(message);
+    res.status(HTTP_STATUS.OK).json(message);
   } catch (error) {
     next(error);
   }
@@ -33,7 +34,7 @@ export const getInterestChannelById = async (req, res, next) => {
     const { userId } = req.params;
     const channels = await getInterestChannelByIdService(Number(userId));
 
-    res.status(200).json(channels);
+    res.status(HTTP_STATUS.OK).json(channels);
   } catch (error) {
     next(error);
   }
@@ -45,9 +46,9 @@ export const updateInterestChannels = async (req, res, next) => {
     const { channelIds } = req.body;
 
     if (!Array.isArray(channelIds)) {
-      return res.status(400).json({
-        status: 400,
-        error: "올바르지 않은 형식입니다.",
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
+        status: HTTP_STATUS.BAD_REQUEST,
+        error: MESSAGES.ERROR.INVALID_FORMAT,
       });
     }
 
@@ -55,7 +56,7 @@ export const updateInterestChannels = async (req, res, next) => {
       Number(userId),
       channelIds
     );
-    res.status(200).json(result);
+    res.status(HTTP_STATUS.OK).json(result);
   } catch (error) {
     next(error);
   }
@@ -67,9 +68,9 @@ export const deleteInterestChannel = async (req, res, next) => {
     const { channelId } = req.body;
 
     if (typeof channelId !== "number") {
-      return res.status(400).json({
-        status: 400,
-        error: "올바르지 않은 형식입니다.",
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
+        status: HTTP_STATUS.BAD_REQUEST,
+        error: MESSAGES.ERROR.INVALID_FORMAT,
       });
     }
 
@@ -78,7 +79,7 @@ export const deleteInterestChannel = async (req, res, next) => {
       Number(channelId)
     );
 
-    res.status(200).json(message);
+    res.status(HTTP_STATUS.OK).json(message);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/users/userSettingController.js
+++ b/src/controllers/users/userSettingController.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import { getUserByIdService } from "../../services/users/userService.js";
 import { updateUserSettingsByIdService } from "../../services/users/userSettingService.js";
 import { stringToSnakeCase } from "../../utils/caseConverter.js";
@@ -16,9 +17,9 @@ export const updateUserSettingsById = async (req, res, next) => {
       const value = req.body?.[reqKey];
       if (value !== undefined) {
         if (typeof value !== "boolean") {
-          return res.status(400).json({
-            status: 400,
-            error: "올바르지 않은 형식입니다.",
+          return res.status(HTTP_STATUS.BAD_REQUEST).json({
+            status: HTTP_STATUS.BAD_REQUEST,
+            error: MESSAGES.ERROR.INVALID_FORMAT,
           });
         }
         updateFields[dbKey] = value;
@@ -26,24 +27,25 @@ export const updateUserSettingsById = async (req, res, next) => {
     }
 
     if (Object.keys(updateFields).length === 0) {
-      return res.status(400).json({
-        status: 400,
-        error: "올바르지 않은 형식입니다.",
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
+        status: HTTP_STATUS.BAD_REQUEST,
+        error: MESSAGES.ERROR.INVALID_FORMAT,
       });
     }
 
     const user = await getUserByIdService(Number(userId));
     if (!user) {
-      return res
-        .status(404)
-        .json({ status: 404, error: "사용자를 찾을 수 없습니다." });
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
+        status: HTTP_STATUS.NOT_FOUND,
+        error: MESSAGES.ERROR.USER_NOT_FOUND,
+      });
     }
 
     const message = await updateUserSettingsByIdService(
       Number(userId),
       updateFields
     );
-    res.status(200).json(message);
+    res.status(HTTP_STATUS.OK).json(message);
   } catch (error) {
     next(error);
   }

--- a/src/services/ad-keywords/adKeywordService.js
+++ b/src/services/ad-keywords/adKeywordService.js
@@ -1,3 +1,4 @@
+import { MESSAGES } from "../../constants/index.js";
 import { toCamelCase } from "../../utils/caseConverter.js";
 import { supabase } from "../supabaseClient.js";
 
@@ -11,7 +12,7 @@ export const getAdKeywordListService = async () => {
 
   if (error) {
     console.error("Supabase error:", error);
-    throw new Error("Supabase query failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_QUERY_FAILED);
   }
 
   if (!data) {

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -1,3 +1,4 @@
+import { MESSAGES } from "../../constants/index.js";
 import { toCamelCase } from "../../utils/caseConverter.js";
 import { supabase } from "../supabaseClient.js";
 
@@ -17,7 +18,7 @@ export const getRadioChannelListService = async () => {
 
   if (error) {
     console.error("Supabase error:", error);
-    throw new Error("Supabase query failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_QUERY_FAILED);
   }
 
   if (!data) {
@@ -52,7 +53,7 @@ export const getRadioChannelByIdService = async (channelId) => {
 
   if (error) {
     console.error("Supabase error:", error);
-    throw new Error("Supabase query failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_QUERY_FAILED);
   }
 
   if (!data) {

--- a/src/services/reports/reportService.js
+++ b/src/services/reports/reportService.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import { toCamelCase } from "../../utils/caseConverter.js";
 import { supabase } from "../supabaseClient.js";
 
@@ -21,14 +22,14 @@ export const createAdReportService = async ({
     .single();
 
   if (error) {
-    throw new Error("Supabase insert failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_INSERT_FAILED);
   }
 
   const camelData = toCamelCase(data);
 
   return {
-    status: 201,
-    message: "광고 제보 등록 성공했습니다.",
+    status: HTTP_STATUS.CREATED,
+    message: MESSAGES.SUCCESS.AD_REPORT_CREATED,
     report: camelData,
   };
 };

--- a/src/services/users/userInterestChannelService.js
+++ b/src/services/users/userInterestChannelService.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import { toCamelCase } from "../../utils/caseConverter.js";
 import { supabase } from "../supabaseClient.js";
 
@@ -9,10 +10,13 @@ export const createInterestChannelService = async (userId, channelId) => {
     .maybeSingle();
 
   if (userError) {
-    throw new Error("Supabase query failed: user check");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: user check`);
   }
   if (!user) {
-    return { status: 404, error: "사용자를 찾을 수 없습니다." };
+    return {
+      status: HTTP_STATUS.NOT_FOUND,
+      error: MESSAGES.ERROR.USER_NOT_FOUND,
+    };
   }
 
   const { data: channel, error: channelError } = await supabase
@@ -22,10 +26,13 @@ export const createInterestChannelService = async (userId, channelId) => {
     .maybeSingle();
 
   if (channelError) {
-    throw new Error("Supabase query failed: channel check");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: channel check`);
   }
   if (!channel) {
-    return { status: 404, error: "채널을 찾을 수 없습니다." };
+    return {
+      status: HTTP_STATUS.NOT_FOUND,
+      error: MESSAGES.ERROR.CHANNEL_NOT_FOUND,
+    };
   }
 
   const { data: existingInterest } = await supabase
@@ -36,7 +43,10 @@ export const createInterestChannelService = async (userId, channelId) => {
     .maybeSingle();
 
   if (existingInterest) {
-    return { status: 400, error: "이미 등록된 관심 채널입니다." };
+    return {
+      status: HTTP_STATUS.BAD_REQUEST,
+      error: MESSAGES.ERROR.INTEREST_CHANNEL_EXISTS,
+    };
   }
 
   const { data: interestList, error: priorityError } = await supabase
@@ -47,7 +57,7 @@ export const createInterestChannelService = async (userId, channelId) => {
     .limit(1);
 
   if (priorityError) {
-    throw new Error("Supabase query failed: priority check");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: priority check`);
   }
 
   const currentMaxPriority = interestList?.[0]?.priority;
@@ -65,10 +75,13 @@ export const createInterestChannelService = async (userId, channelId) => {
     ]);
 
   if (insertError) {
-    throw new Error("Supabase insert failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_INSERT_FAILED);
   }
 
-  return { status: 201, message: "관심 채널 등록 성공했습니다." };
+  return {
+    status: HTTP_STATUS.CREATED,
+    message: MESSAGES.SUCCESS.INTEREST_CHANNEL_CREATED,
+  };
 };
 
 export const getInterestChannelByIdService = async (userId) => {
@@ -79,8 +92,7 @@ export const getInterestChannelByIdService = async (userId) => {
     .order("priority", { ascending: true });
 
   if (error) {
-    console.error("Supabase error:", error);
-    throw new Error("Supabase query failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_QUERY_FAILED);
   }
 
   const camelData = toCamelCase(data);
@@ -96,10 +108,13 @@ export const updateInterestChannelsService = async (userId, channelIds) => {
     .maybeSingle();
 
   if (userError) {
-    throw new Error("Supabase query failed: user check");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: user check`);
   }
   if (!user) {
-    return { status: 404, error: "사용자를 찾을 수 없습니다." };
+    return {
+      status: HTTP_STATUS.NOT_FOUND,
+      error: MESSAGES.ERROR.USER_NOT_FOUND,
+    };
   }
 
   const { data: validChannels, error: channelError } = await supabase
@@ -108,7 +123,7 @@ export const updateInterestChannelsService = async (userId, channelIds) => {
     .in("id", channelIds);
 
   if (channelError) {
-    throw new Error("Supabase query failed: channel check");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: channel check`);
   }
 
   const validChannelIds = validChannels.map((channel) => channel.id);
@@ -118,8 +133,8 @@ export const updateInterestChannelsService = async (userId, channelIds) => {
 
   if (invalidChannelIds.length > 0) {
     return {
-      status: 404,
-      error: "존재하지 않는 채널이 포함되어 있습니다.",
+      status: HTTP_STATUS.NOT_FOUND,
+      error: MESSAGES.ERROR.INVALID_CHANNELS,
     };
   }
 
@@ -129,7 +144,7 @@ export const updateInterestChannelsService = async (userId, channelIds) => {
     .eq("user_id", userId);
 
   if (deleteError) {
-    throw new Error("Supabase delete failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_DELETE_FAILED);
   }
 
   const insertData = channelIds.map((id, index) => ({
@@ -143,10 +158,13 @@ export const updateInterestChannelsService = async (userId, channelIds) => {
     .insert(insertData);
 
   if (insertError) {
-    throw new Error("Supabase insert failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_INSERT_FAILED);
   }
 
-  return { status: 200, message: "관심 채널 갱신에 성공했습니다." };
+  return {
+    status: HTTP_STATUS.OK,
+    message: MESSAGES.SUCCESS.INTEREST_CHANNELS_UPDATED,
+  };
 };
 
 export const deleteInterestChannelService = async (userId, channelId) => {
@@ -157,10 +175,13 @@ export const deleteInterestChannelService = async (userId, channelId) => {
     .maybeSingle();
 
   if (userError) {
-    throw new Error("Supabase query failed: user check");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: user check`);
   }
   if (!user) {
-    return { status: 404, error: "사용자를 찾을 수 없습니다." };
+    return {
+      status: HTTP_STATUS.NOT_FOUND,
+      error: MESSAGES.ERROR.USER_NOT_FOUND,
+    };
   }
 
   const { data: channel, error: channelError } = await supabase
@@ -170,10 +191,13 @@ export const deleteInterestChannelService = async (userId, channelId) => {
     .maybeSingle();
 
   if (channelError) {
-    throw new Error("Supabase query failed: channel check");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: channel check`);
   }
   if (!channel) {
-    return { status: 404, error: "채널을 찾을 수 없습니다." };
+    return {
+      status: HTTP_STATUS.NOT_FOUND,
+      error: MESSAGES.ERROR.CHANNEL_NOT_FOUND,
+    };
   }
 
   const { data: interest, error: interestError } = await supabase
@@ -184,10 +208,13 @@ export const deleteInterestChannelService = async (userId, channelId) => {
     .maybeSingle();
 
   if (interestError) {
-    throw new Error("Supabase query failed: interest check");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: interest check`);
   }
   if (!interest) {
-    return { status: 404, error: "등록된 관심 채널이 없습니다." };
+    return {
+      status: HTTP_STATUS.NOT_FOUND,
+      error: MESSAGES.ERROR.INTEREST_CHANNEL_NOT_FOUND,
+    };
   }
 
   const removedPriority = interest.priority;
@@ -199,7 +226,7 @@ export const deleteInterestChannelService = async (userId, channelId) => {
     .eq("channel_id", channelId);
 
   if (deleteError) {
-    throw new Error("Supabase delete failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_DELETE_FAILED);
   }
 
   const { data: channelsToUpdate, error: selectError } = await supabase
@@ -209,7 +236,7 @@ export const deleteInterestChannelService = async (userId, channelId) => {
     .gt("priority", removedPriority);
 
   if (selectError) {
-    throw new Error("Supabase query failed: reorder");
+    throw new Error(`${MESSAGES.ERROR.SUPABASE_QUERY_FAILED}: reorder`);
   }
 
   for (const item of channelsToUpdate) {
@@ -220,5 +247,8 @@ export const deleteInterestChannelService = async (userId, channelId) => {
       .eq("channel_id", item.channel_id);
   }
 
-  return { status: 200, message: "관심 채널 삭제 성공했습니다." };
+  return {
+    status: HTTP_STATUS.OK,
+    message: MESSAGES.SUCCESS.INTEREST_CHANNEL_DELETED,
+  };
 };

--- a/src/services/users/userService.js
+++ b/src/services/users/userService.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import { toCamelCase } from "../../utils/caseConverter.js";
 import { supabase } from "../supabaseClient.js";
 
@@ -8,12 +9,12 @@ export const createUserService = async (insertFields) => {
     .select();
 
   if (error && !data) {
-    throw new Error("Supabase insert failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_INSERT_FAILED);
   }
 
   return {
-    status: 201,
-    message: "사용자 등록 성공했습니다.",
+    status: HTTP_STATUS.CREATED,
+    message: MESSAGES.SUCCESS.USER_CREATED,
     userId: data?.[0]?.id,
   };
 };
@@ -37,7 +38,7 @@ export const getUserByIdService = async (userId) => {
 
   if (error) {
     console.error("Supabase error:", error);
-    throw new Error("Supabase query failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_QUERY_FAILED);
   }
 
   if (!data) {

--- a/src/services/users/userSettingService.js
+++ b/src/services/users/userSettingService.js
@@ -1,3 +1,4 @@
+import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import { supabase } from "../supabaseClient.js";
 
 export const updateUserSettingsByIdService = async (userId, updateFields) => {
@@ -8,11 +9,11 @@ export const updateUserSettingsByIdService = async (userId, updateFields) => {
 
   if (error) {
     console.error("Supabase update error:", error);
-    throw new Error("Supabase update failed");
+    throw new Error(MESSAGES.ERROR.SUPABASE_UPDATE_FAILED);
   }
 
   return {
-    status: 200,
-    message: "사용자 설정이 성공적으로 변경되었습니다.",
+    status: HTTP_STATUS.OK,
+    message: MESSAGES.SUCCESS.USER_SETTINGS_UPDATED,
   };
 };

--- a/src/validators/channelValidator.js
+++ b/src/validators/channelValidator.js
@@ -1,10 +1,12 @@
+import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
+
 export const validateChannelId = (req, res, next) => {
   const { channelId } = req.params;
 
   if (Number.isNaN(Number(channelId))) {
-    return res.status(400).json({
-      status: 400,
-      error: "올바르지 않은 형식입니다.",
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
+      status: HTTP_STATUS.BAD_REQUEST,
+      error: MESSAGES.ERROR.INVALID_FORMAT,
     });
   }
 

--- a/src/validators/reportValidator.js
+++ b/src/validators/reportValidator.js
@@ -1,3 +1,5 @@
+import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
+
 export const validateReportBody = (req, res, next) => {
   const { userId, isAd, detectedAdPhrase, channelId } = req.body || {};
 
@@ -8,9 +10,9 @@ export const validateReportBody = (req, res, next) => {
     typeof channelId !== "number";
 
   if (isInvalidFormat) {
-    return res.status(400).json({
-      status: 400,
-      error: "올바르지 않은 형식입니다.",
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
+      status: HTTP_STATUS.BAD_REQUEST,
+      error: MESSAGES.ERROR.INVALID_FORMAT,
     });
   }
 

--- a/src/validators/userValidator.js
+++ b/src/validators/userValidator.js
@@ -1,10 +1,12 @@
+import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
+
 export const validateUserId = (req, res, next) => {
   const { userId } = req.params;
 
   if (Number.isNaN(Number(userId))) {
-    return res.status(400).json({
-      status: 400,
-      error: "올바르지 않은 형식입니다.",
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
+      status: HTTP_STATUS.BAD_REQUEST,
+      error: MESSAGES.ERROR.INVALID_FORMAT,
     });
   }
 


### PR DESCRIPTION
### ✨ 이슈 번호

- #30 

### 📌 설명

- 코드 일관성을 높이고 관리 효율성을 개선하기 위해 공통 상수로 분리를 구현하여 작성한 Pull Request입니다.
  - 매직 넘버로 사용되고 있는 HTTP 상태 코드 (매직 넘버 : 의미 있는 이름의 상수로 대체될 수 있는 숫자)
  - 응답 메시지

### 📃 작업 사항

- [x] HTTP 상태 코드 상수화
  - [x] 200, 201, 400, 404, 500 등 자주 사용하는 코드 상수화
  - [x] constants/httpStatus.js 파일 생성
- [x] 응답 메시지 상수화
  - [x] 하드코딩되어 있는 성공/에러 메시지 상수화
  - [x] constants/messages.js 파일 생성
- [x] 모든 상수를 한 곳에서 export해주는 constants/index.js 파일 생성

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
