### PR TITLE
feat: 방송사 및 is_api_exposed 조건에 따른 라디오 스트리밍 URL 처리 로직 구현

### DIFF
--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -60,6 +60,8 @@ export const getRadioChannelByIdService = async (channelId) => {
     return null;
   }
 
+  data.url = await getRadioChannelUrlService(data);
+
   const camelData = toCamelCase(data);
 
   return {
@@ -67,4 +69,32 @@ export const getRadioChannelByIdService = async (channelId) => {
     userId: camelData.id,
     areaName: camelData.areas?.name,
   };
+};
+
+export const getRadioChannelUrlService = async (data) => {
+  if (!data.is_api_exposed) {
+    return data.url;
+  }
+
+  const response = await fetch(data.url);
+  let result;
+
+  switch (data.station) {
+    case "KBS": {
+      const json = await response.json();
+      result = json.channel_item[0].service_url;
+      break;
+    }
+    case "MBC":
+    case "SBS": {
+      result = await response.text();
+      break;
+    }
+    default: {
+      result = data.url;
+      break;
+    }
+  }
+
+  return result;
 };

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -60,19 +60,19 @@ export const getRadioChannelByIdService = async (channelId) => {
     return null;
   }
 
-  data.url = await getRadioChannelUrlService(data);
-
   const camelData = toCamelCase(data);
+  const streamingUrl = await getRadioChannelUrlService(camelData);
 
   return {
     ...camelData,
     userId: camelData.id,
     areaName: camelData.areas?.name,
+    url: streamingUrl,
   };
 };
 
 export const getRadioChannelUrlService = async (data) => {
-  if (!data.is_api_exposed) {
+  if (!data.isApiExposed) {
     return data.url;
   }
 

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -71,12 +71,16 @@ export const getRadioChannelByIdService = async (channelId) => {
   };
 };
 
-export const getRadioChannelUrlService = async (data) => {
-  if (!data.isApiExposed) {
-    return data.url;
+export const getRadioChannelUrlService = async ({
+  isApiExposed,
+  url,
+  station,
+}) => {
+  if (!isApiExposed) {
+    return url;
   }
 
-  const response = await fetch(data.url);
+  const response = await fetch(url);
 
   if (!response.ok) {
     throw new Error(MESSAGES.STATION_FAILED);
@@ -84,7 +88,7 @@ export const getRadioChannelUrlService = async (data) => {
 
   let result;
 
-  switch (data.station) {
+  switch (station) {
     case "KBS": {
       const json = await response.json();
       result = json.channel_item[0].service_url;
@@ -96,7 +100,7 @@ export const getRadioChannelUrlService = async (data) => {
       break;
     }
     default: {
-      result = data.url;
+      result = url;
       break;
     }
   }

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -77,6 +77,11 @@ export const getRadioChannelUrlService = async (data) => {
   }
 
   const response = await fetch(data.url);
+
+  if (!response.ok) {
+    throw new Error(MESSAGES.STATION_FAILED);
+  }
+
   let result;
 
   switch (data.station) {

--- a/src/sockets/index.js
+++ b/src/sockets/index.js
@@ -1,6 +1,6 @@
 import { Server } from "socket.io";
 
-import registerSocketHandler from "./handlers";
+import registerSocketHandler from "./handlers/index.js";
 
 export const initSocket = (server) => {
   const io = new Server(server, {


### PR DESCRIPTION
### ✨ 이슈 번호

- #36 

### 📌 설명

클라이언트에서 라디오 채널을 선택하면, 서버는 Supabase에 저장된 채널 정보를 조회한 뒤 해당 채널의 스트리밍 URL을 반환하는 Pull Request입니다.

각 채널은 `is_api_exposed`라는 필드를 가지고 있고 이 값에 따라 스트리밍 URL을 처리하는 방식이 달라집니다.

- `is_api_exposed`가 **false**인 경우: Supabase에 저장된 URL을 그대로 사용합니다.
- `is_api_exposed`가 **true**인 경우: 방송사(KBS, MBC, SBS)에 따라 서버가 URL에 직접 요청을 보내고, 응답으로부터 실제 재생 가능한 스트리밍 URL을 추출해 사용합니다.

### 📃 작업 사항

- [X] Supabase에서 채널 정보 조회
- [X] `isApiExposed`가 true인 경우
  - [X] 서버에서 직접 스트리밍 URL(m3u8) 요청 및 처리
  - [X] `fetch`로 각 방송사 별 URL 처리
- [X] `isApiExposed`가 false인 경우
  - [X] 해당 URL을 그대로 사용

### 💭 리뷰 사항 반영 


### ✅ Pull Request 체크 사항

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.
