### PR TITLE
feat: Whisper 서버에 스트리밍 URL 전달 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.8",
+    "axios": "^1.9.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -1,5 +1,6 @@
 import { MESSAGES } from "../../constants/index.js";
 import { toCamelCase } from "../../utils/caseConverter.js";
+import { sendStreamUrlToWhisper } from "../../utils/sendStreamUrlToWhisper.js";
 import { supabase } from "../supabaseClient.js";
 
 export const getRadioChannelListService = async () => {
@@ -62,6 +63,7 @@ export const getRadioChannelByIdService = async (channelId) => {
 
   const camelData = toCamelCase(data);
   const streamingUrl = await getRadioChannelUrlService(camelData);
+  sendStreamUrlToWhisper(streamingUrl);
 
   return {
     ...camelData,

--- a/src/utils/sendStreamingUrlToWhisper.js
+++ b/src/utils/sendStreamingUrlToWhisper.js
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+export const sendStreamUrlToWhisper = async (url) => {
+  try {
+    await axios.post("http://localhost:5000/transcribe", {
+      url: url,
+    });
+  } catch (error) {
+    console.error("❌ Whisper 서버 요청 실패", error?.message);
+  }
+};

--- a/src/utils/sendStreamingUrlToWhisper.js
+++ b/src/utils/sendStreamingUrlToWhisper.js
@@ -2,6 +2,7 @@ import axios from "axios";
 
 export const sendStreamUrlToWhisper = async (url) => {
   try {
+    // TODO: Whisper 서버 배포 시 주소 변경
     await axios.post("http://localhost:5000/transcribe", {
       url: url,
     });


### PR DESCRIPTION
### ✨ 이슈 번호

- #39 

### 📌 설명

- Whisper 서버에 라디오 스트리밍 URL을 전달하기 위한 HTTP 요청 기능 구현한 Pull Request입니다.
- axios를 사용하여 Express 기반 Node.js 서버에서 Whisper 서버로 POST 요청을 보냅니다.

### 📃 작업 사항

- [x] axios 설치 (npm install axios)
- [x] Whisper 서버에 스트리밍 URL 전송 기능 구현
- [x] 에러 처리

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
