### PR TITLE
feat: 방송사 통신 실패 메시지 상수 정의

### DIFF
--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -14,6 +14,7 @@ export const MESSAGES = {
     INTEREST_CHANNEL_EXISTS: "이미 등록된 관심 채널입니다.",
     INTEREST_CHANNEL_NOT_FOUND: "등록된 관심 채널이 없습니다.",
     INVALID_CHANNELS: "존재하지 않는 채널이 포함되어 있습니다.",
+    STATION_FAILED: "방송사와의 통신에 실패했습니다.",
     SUPABASE_QUERY_FAILED: "Supabase query failed",
     SUPABASE_INSERT_FAILED: "Supabase insert failed",
     SUPABASE_DELETE_FAILED: "Supabase delete failed",


### PR DESCRIPTION
### ✨ 이슈 번호 

- #41 

### 📌 설명 

- 방송사 스트리밍 URL을 요청하는 과정에서 실패할 수 있는 상황에 대비하여, 사용자에게 안내할 예외 메시지 상수를 추가한 Pull Request입니다.

### 📃 작업 사항 

- [X] `MESSAGES.STATION_FAILED` 상수 정의
  - [X] 메시지: "방송사와의 통신에 실패했습니다." -> 방송사 URL 요청(fetch) 실패 시 해당 메시지로 예외 처리

### 💭 리뷰 사항 반영 

### ✅ Pull Request 체크 사항

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.
