### PR TITLE
feat: 광고 감지 여부에 따른 whisper 서버 연결

### DIFF
--- a/src/controllers/radio-channels/radioChannelController.js
+++ b/src/controllers/radio-channels/radioChannelController.js
@@ -17,7 +17,12 @@ export const getRadioChannelList = async (_req, res, next) => {
 export const getRadioChannelById = async (req, res, next) => {
   try {
     const { channelId } = req.params;
-    const channel = await getRadioChannelByIdService(Number(channelId));
+    const isAdDetect = req.query.isAdDetect === "true";
+
+    const channel = await getRadioChannelByIdService(
+      Number(channelId),
+      isAdDetect
+    );
 
     if (!channel) {
       return res.status(HTTP_STATUS.NOT_FOUND).json({

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -32,7 +32,7 @@ export const getRadioChannelListService = async () => {
   return camelData;
 };
 
-export const getRadioChannelByIdService = async (channelId) => {
+export const getRadioChannelByIdService = async (channelId, isAdDetect) => {
   const { data, error } = await supabase
     .from("channels")
     .select(
@@ -65,7 +65,9 @@ export const getRadioChannelByIdService = async (channelId) => {
 
   const camelData = toCamelCase(data);
   const streamingUrl = await getRadioChannelUrlService(camelData);
-  sendStreamingUrlToWhisper(streamingUrl);
+  if (isAdDetect) {
+    sendStreamingUrlToWhisper(streamingUrl);
+  }
 
   return {
     ...camelData,


### PR DESCRIPTION
### ✨ 이슈 번호

- #52 

### 📌 설명

- 광고 감지 여부에 따른 whisper 서버 연결을 구현하여 작성한 Pull Request입니다.
- 기존에는 /radio-channels/:channelId 요청 시 Whisper 서버로 스트리밍 URL을 항상 전달하고 있었지만,
프론트엔드에서 광고 감지 기능이 비활성화된 상태에서도 Whisper 요청이 발생하는 문제를 방지하기 위해
isAdDetect 쿼리 파라미터를 받아 해당 값이 true인 경우에만 Whisper 서버로 요청을 보내도록 합니다.

### 📃 작업 사항

- [x] 컨트롤러에서 isAdDetect param을 getRadioChannelByIdService에 전달
- [x] getRadioChannelByIdService(channelId, isAdDetect)로 매개변수 추가
- [x] isAdDetect가 true일 경우에만 sendStreamingUrlToWhisper 호출

### 💡 참고 사항

- 프론트엔드와 함께 진행된 PR입니다.
- [프론트엔드 광고 감지 여부에 따른 whisper 서버 연결 PR](https://github.com/Radio-Premium/RadioPremium-FE/pull/78)

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
