### PR TITLE
feat: 광고 없는 채널 중 랜덤 채널 반환 API 구현

### DIFF
--- a/src/controllers/radio-channels/radioChannelController.js
+++ b/src/controllers/radio-channels/radioChannelController.js
@@ -2,7 +2,7 @@ import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import {
   getRadioChannelListService,
   getRadioChannelByIdService,
-  getRandomAdChannelService,
+  getRandomNoAdChannelService,
 } from "../../services/radio-channels/radioChannelService.js";
 
 export const getRadioChannelList = async (_req, res, next) => {
@@ -38,9 +38,9 @@ export const getRadioChannelById = async (req, res, next) => {
   }
 };
 
-export const getRandomAdChannel = async (_req, res, next) => {
+export const getRandomNoAdChannel = async (_req, res, next) => {
   try {
-    const randomChannel = await getRandomAdChannelService();
+    const randomChannel = await getRandomNoAdChannelService();
 
     if (!randomChannel) {
       return res.status(HTTP_STATUS.NOT_FOUND).json({

--- a/src/controllers/radio-channels/radioChannelController.js
+++ b/src/controllers/radio-channels/radioChannelController.js
@@ -2,6 +2,7 @@ import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import {
   getRadioChannelListService,
   getRadioChannelByIdService,
+  getRandomAdChannelService,
 } from "../../services/radio-channels/radioChannelService.js";
 
 export const getRadioChannelList = async (_req, res, next) => {
@@ -32,6 +33,23 @@ export const getRadioChannelById = async (req, res, next) => {
     }
 
     res.status(HTTP_STATUS.OK).json(channel);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getRandomAdChannel = async (_req, res, next) => {
+  try {
+    const randomChannel = await getRandomAdChannelService();
+
+    if (!randomChannel) {
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
+        status: HTTP_STATUS.NOT_FOUND,
+        error: MESSAGES.ERROR.CHANNEL_NOT_FOUND,
+      });
+    }
+
+    return res.status(HTTP_STATUS.OK).json(randomChannel);
   } catch (error) {
     next(error);
   }

--- a/src/routes/radio-channels/index.js
+++ b/src/routes/radio-channels/index.js
@@ -3,12 +3,14 @@ import express from "express";
 import {
   getRadioChannelList,
   getRadioChannelById,
+  getRandomAdChannel,
 } from "../../controllers/radio-channels/radioChannelController.js";
 import { validateChannelId } from "../../validators/channelValidator.js";
 
 const router = express.Router();
 
 router.get("", getRadioChannelList);
+router.get("/random-ad", getRandomAdChannel);
 router.get("/:channelId", validateChannelId, getRadioChannelById);
 
 export default router;

--- a/src/routes/radio-channels/index.js
+++ b/src/routes/radio-channels/index.js
@@ -10,7 +10,7 @@ import { validateChannelId } from "../../validators/channelValidator.js";
 const router = express.Router();
 
 router.get("", getRadioChannelList);
-router.get("/random-ad", getRandomNoAdChannel);
+router.get("/random-no-ad", getRandomNoAdChannel);
 router.get("/:channelId", validateChannelId, getRadioChannelById);
 
 export default router;

--- a/src/routes/radio-channels/index.js
+++ b/src/routes/radio-channels/index.js
@@ -3,14 +3,14 @@ import express from "express";
 import {
   getRadioChannelList,
   getRadioChannelById,
-  getRandomAdChannel,
+  getRandomNoAdChannel,
 } from "../../controllers/radio-channels/radioChannelController.js";
 import { validateChannelId } from "../../validators/channelValidator.js";
 
 const router = express.Router();
 
 router.get("", getRadioChannelList);
-router.get("/random-ad", getRandomAdChannel);
+router.get("/random-ad", getRandomNoAdChannel);
 router.get("/:channelId", validateChannelId, getRadioChannelById);
 
 export default router;

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -113,3 +113,45 @@ export const getRadioChannelUrlService = async ({
 
   return result;
 };
+
+export const getRandomAdChannelService = async () => {
+  const { data, error } = await supabase
+    .from("channels")
+    .select(
+      `
+      id,
+      station,
+      name,
+      area_id,
+      url,
+      is_api_exposed,
+      logo_url,
+      is_ad_channel,
+      created_at,
+      areas (
+        name
+      )
+      `
+    )
+    .eq("is_ad_channel", false);
+
+  if (error) {
+    console.error("Supabase error:", error);
+    throw new Error(MESSAGES.ERROR.SUPABASE_QUERY_FAILED);
+  }
+
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  const randomIndex = Math.floor(Math.random() * data.length);
+  const randomChannel = data[randomIndex];
+  const camelData = toCamelCase(randomChannel);
+  const streamingUrl = await getRadioChannelUrlService(camelData);
+
+  return {
+    ...camelData,
+    areaName: camelData.areas?.name,
+    url: streamingUrl,
+  };
+};

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -114,7 +114,7 @@ export const getRadioChannelUrlService = async ({
   return result;
 };
 
-export const getRandomAdChannelService = async () => {
+export const getRandomNoAdChannelService = async () => {
   const { data, error } = await supabase
     .from("channels")
     .select(


### PR DESCRIPTION
### ✨ 이슈 번호

- #54 

### 📌 설명

- 광고 없는 라디오 채널 조회 API를 구현하여 작성한 Pull Request입니다.
- 광고 감지된 상황에서 대체할 수 있는 채널을 랜덤으로 제공하기 위해, `is_ad_channel=false` 조건을 만족하는 채널 중 하나를 랜덤으로 선택하여 반환하는 API를 구현하였습니다.

### 📃 작업 사항

- [x] getRandomAdChannelService 서비스 함수 구현
  - [x] channels 테이블에서 is_ad_channel = true인 데이터 중 랜덤으로 하나 선택
- [x] getRandomAdChannel 컨트롤러 구현
  - [x] 클라이언트 요청 시 getRandomAdChannelService 서비스 함수를 호출하여 결과 반환
- [x] 예외 처리 및 오류 메시지 정의

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
