### PR TITLE
feat: 광고 종료 감지 및 이전 채널 복귀 구현

### DIFF
--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -4,10 +4,9 @@ import { getUserByIdService } from "../../services/users/userService.js";
 let isAdPlaying = false;
 let adEndTimers = new Map();
 
-const transcribedTextHandler = (whisperSocket, io, userMap) => {
-  whisperSocket.off("transcribedRadioText");
-
-  whisperSocket.on("transcribedRadioText", async ({ text, userId }) => {
+const handleTranscribedText =
+  (io, userMap) =>
+  async ({ text, userId }) => {
     console.log("[Whisper] Received text:", text);
     const socketId = userMap.get(userId);
     if (!socketId) return;
@@ -47,7 +46,13 @@ const transcribedTextHandler = (whisperSocket, io, userMap) => {
 
       adEndTimers.set(userId, timer);
     }
-  });
+  };
+
+const transcribedTextHandler = (whisperSocket, io, userMap) => {
+  const listener = handleTranscribedText(io, userMap);
+
+  whisperSocket.off("transcribedRadioText", listener);
+  whisperSocket.on("transcribedRadioText", listener);
 
   whisperSocket.on("disconnect", () => {
     console.log("Whisper disconnected");

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -1,5 +1,5 @@
 import { getAdKeywords } from "../../cache/adKeywordCache.js";
-import { getUserByIdService } from "../../services/users/index.js";
+import { getUserByIdService } from "../../services/users/userService.js";
 
 let isAdPlaying = false;
 let adEndTimers = new Map();

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -2,6 +2,7 @@ import { getAdKeywords } from "../../cache/adKeywordCache.js";
 import { getUserByIdService } from "../../services/users/index.js";
 
 let isAdPlaying = false;
+let adEndTimers = new Map();
 
 const transcribedTextHandler = (whisperSocket, io, userMap) => {
   whisperSocket.off("transcribedRadioText");
@@ -13,24 +14,37 @@ const transcribedTextHandler = (whisperSocket, io, userMap) => {
     const keywords = getAdKeywords();
     const matched = keywords.find((keyword) => text.includes(keyword));
 
-    if (matched && !isAdPlaying) {
-      io.to(socketId).emit("radioText", { isAd: true });
-      isAdPlaying = true;
+    if (matched) {
+      if (!isAdPlaying) {
+        io.to(socketId).emit("radioText", { isAd: true });
+        isAdPlaying = true;
+      }
+
+      if (adEndTimers.has(userId)) {
+        clearTimeout(adEndTimers.get(userId));
+        adEndTimers.delete(userId);
+      }
+
       return;
     }
 
-    if (!matched && isAdPlaying) {
-      try {
-        const user = await getUserByIdService(userId);
+    if (isAdPlaying && !adEndTimers.has(userId)) {
+      const timer = setTimeout(async () => {
+        try {
+          const user = await getUserByIdService(userId);
 
-        if (user.isReturnChannel) {
-          io.to(socketId).emit("radioText", { isAd: false });
+          if (user.isReturnChannel) {
+            io.to(socketId).emit("radioText", { isAd: false });
+          }
+
+          isAdPlaying = false;
+          adEndTimers.delete(userId);
+        } catch (error) {
+          console.error("Failed to fetch user information", error);
         }
+      }, 5000);
 
-        isAdPlaying = false;
-      } catch (error) {
-        console.error("Failed to fetch user information", error);
-      }
+      adEndTimers.set(userId, timer);
     }
   });
 

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -11,8 +11,8 @@ const handleTranscribedText =
     const socketId = userMap.get(userId);
     if (!socketId) return;
 
-    const keywords = getAdKeywords();
-    const matched = keywords.find((keyword) => text.includes(keyword));
+    const keywordList = getAdKeywords();
+    const matched = keywordList.find(({ keyword }) => text.includes(keyword));
 
     if (matched) {
       if (!isAdPlaying) {

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -9,7 +9,9 @@ const handleTranscribedText =
   async ({ text, userId }) => {
     console.log("[Whisper] Received text:", text);
     const socketId = userMap.get(userId);
-    if (!socketId) return;
+    if (!socketId) {
+      return;
+    }
 
     const keywordList = getAdKeywords();
     const matched = keywordList.find(({ keyword }) => text.includes(keyword));

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -10,6 +10,7 @@ const transcribedTextHandler = (whisperSocket, io, userMap) => {
   whisperSocket.on("transcribedRadioText", async ({ text, userId }) => {
     console.log("[Whisper] Received text:", text);
     const socketId = userMap.get(userId);
+    if (!socketId) return;
 
     const keywords = getAdKeywords();
     const matched = keywords.find((keyword) => text.includes(keyword));

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -2,7 +2,7 @@ import { getAdKeywords } from "../../cache/adKeywordCache.js";
 import { getUserByIdService } from "../../services/users/userService.js";
 
 let isAdPlaying = false;
-let adEndTimers = new Map();
+const userAdEndTimers = new Map();
 
 const handleTranscribedText =
   (io, userMap) =>
@@ -22,15 +22,15 @@ const handleTranscribedText =
         isAdPlaying = true;
       }
 
-      if (adEndTimers.has(userId)) {
-        clearTimeout(adEndTimers.get(userId));
-        adEndTimers.delete(userId);
+      if (userAdEndTimers.has(userId)) {
+        clearTimeout(userAdEndTimers.get(userId));
+        userAdEndTimers.delete(userId);
       }
 
       return;
     }
 
-    if (isAdPlaying && !adEndTimers.has(userId)) {
+    if (isAdPlaying && !userAdEndTimers.has(userId)) {
       const timer = setTimeout(async () => {
         try {
           const user = await getUserByIdService(userId);
@@ -40,13 +40,13 @@ const handleTranscribedText =
           }
 
           isAdPlaying = false;
-          adEndTimers.delete(userId);
+          userAdEndTimers.delete(userId);
         } catch (error) {
           console.error("Failed to fetch user information", error);
         }
       }, 5000);
 
-      adEndTimers.set(userId, timer);
+      userAdEndTimers.set(userId, timer);
     }
   };
 

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -1,18 +1,36 @@
 import { getAdKeywords } from "../../cache/adKeywordCache.js";
+import { getUserByIdService } from "../../services/users/index.js";
+
+let isAdPlaying = false;
 
 const transcribedTextHandler = (whisperSocket, io, userMap) => {
   whisperSocket.off("transcribedRadioText");
 
-  whisperSocket.on("transcribedRadioText", ({ text, userId }) => {
+  whisperSocket.on("transcribedRadioText", async ({ text, userId }) => {
     console.log("[Whisper] Received text:", text);
     const socketId = userMap.get(userId);
 
     const keywords = getAdKeywords();
     const matched = keywords.find((keyword) => text.includes(keyword));
 
-    if (matched) {
-      console.log(`🔔 광고 키워드 감지: "${matched}"`);
+    if (matched && !isAdPlaying) {
       io.to(socketId).emit("radioText", { isAd: true });
+      isAdPlaying = true;
+      return;
+    }
+
+    if (!matched && isAdPlaying) {
+      try {
+        const user = await getUserByIdService(userId);
+
+        if (user.isReturnChannel) {
+          io.to(socketId).emit("radioText", { isAd: false });
+        }
+
+        isAdPlaying = false;
+      } catch (error) {
+        console.error("Failed to fetch user information", error);
+      }
     }
   });
 

--- a/src/sockets/handlers/userConnectionHandler.js
+++ b/src/sockets/handlers/userConnectionHandler.js
@@ -1,10 +1,15 @@
 const registerUserConnectionHandler = (socket, userMap) => {
+  let currentUserId = null;
+
   socket.on("registerUser", ({ userId }) => {
+    currentUserId = userId;
     userMap.set(userId, socket.id);
   });
 
   socket.on("disconnect", () => {
-    userMap.delete(socket.id);
+    if (currentUserId) {
+      userMap.delete(currentUserId);
+    }
   });
 };
 


### PR DESCRIPTION
### ✨ 이슈 번호

- #56 

### 📌 설명

- Whisper 서버에서 수신한 텍스트 내 광고 키워드 감지 후, 사용자 설정에 따라 광고 종료 시 채널 복귀 여부를 처리하는 로직을 구현한 Pull Request입니다.
- 코드 가독성을 위해 이벤트 처리 로직을 함수로 분리하고, 광고 종료 시 타이머 기반의 복귀 로직을 구현했습니다.

### 📃 작업 사항

- [x] 사용자 설정을 기준으로 광고 종료 시 채널 복귀 여부 판단 로직 구현
- [x] 광고 키워드가 감지되지 않을 경우, 일정 시간(5초) 후 채널 복귀 처리 타이머 추가
- [x] Whisper 텍스트 처리 로직을 `handleTranscribedText` 함수로 분리

### 💭 리뷰 사항 반영

- [x] 단일 if문에 중괄호 추가
- [x] const로 변경 및 userAdEndTimers로 네이밍 수정

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
