### PR TITLE
fix: Whisper 요청 처리를 위한 /whisper API 추가

### DIFF
--- a/src/controllers/whisper/whisperController.js
+++ b/src/controllers/whisper/whisperController.js
@@ -1,0 +1,11 @@
+import { sendStreamingUrlToWhisper } from "../../utils/sendStreamingUrlToWhisper.js";
+
+export const postWhisperRequest = async (req, res, next) => {
+  try {
+    const { streamingUrl, userId, channelId } = req.body;
+    await sendStreamingUrlToWhisper(streamingUrl, userId, channelId);
+    res.status(200).json({ message: "Whisper 요청 전송 완료" });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/whisper/index.js
+++ b/src/routes/whisper/index.js
@@ -1,0 +1,9 @@
+import express from "express";
+
+import { postWhisperRequest } from "../../controllers/whisper/whisperController.js";
+
+const router = express.Router();
+
+router.post("/", postWhisperRequest);
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ import adKeywordRoutes from "./routes/ad-keywords/index.js";
 import radioChannelRoutes from "./routes/radio-channels/index.js";
 import reportRoutes from "./routes/reports/index.js";
 import userRoutes from "./routes/users/index.js";
+import whisperRoutes from "./routes/whisper/index.js";
 import { initSocket } from "./sockets/index.js";
 
 dotenv.config();
@@ -20,6 +21,7 @@ app.use("/ad-keywords", adKeywordRoutes);
 app.use("/users", userRoutes);
 app.use("/reports", reportRoutes);
 app.use("/radio-channels", radioChannelRoutes);
+app.use("/whisper", whisperRoutes);
 
 app.use(errorHandler);
 

--- a/src/services/radio-channels/radioChannelService.js
+++ b/src/services/radio-channels/radioChannelService.js
@@ -1,6 +1,5 @@
 import { MESSAGES } from "../../constants/index.js";
 import { toCamelCase } from "../../utils/caseConverter.js";
-import { sendStreamingUrlToWhisper } from "../../utils/sendStreamingUrlToWhisper.js";
 import { supabase } from "../supabaseClient.js";
 
 export const getRadioChannelListService = async () => {
@@ -32,11 +31,7 @@ export const getRadioChannelListService = async () => {
   return camelData;
 };
 
-export const getRadioChannelByIdService = async (
-  channelId,
-  isAdDetect,
-  userId
-) => {
+export const getRadioChannelByIdService = async (channelId) => {
   const { data, error } = await supabase
     .from("channels")
     .select(
@@ -69,9 +64,6 @@ export const getRadioChannelByIdService = async (
 
   const camelData = toCamelCase(data);
   const streamingUrl = await getRadioChannelUrlService(camelData);
-  if (isAdDetect) {
-    sendStreamingUrlToWhisper(streamingUrl, userId);
-  }
 
   return {
     ...camelData,


### PR DESCRIPTION
### ✨ 이슈 번호

- #61

### 📌 설명

- 프론트에서 사용자 재생 요청 채널에만 Whisper 서버를 호출하도록 로직이 개선됨에 따라,  
백엔드에서도 Whisper 호출 로직을 `getRadioChannelByIdService`에서 분리하고 `/whisper` API를 통해 별도로 처리할 수 있도록 구조를 개선한 Pull Request입니다.

### 📃 작업 사항

- [x] getRadioChannelByIdService를 채널 정보만 가져오도록 관심사 분리
  - [x] whisper 서버 호출 함수 추출
- [x] Whisper 요청 처리용 컨트롤러(postWhisperRequest) 추가
- [x] /whisper 라우트 등록 및 Whisper 요청 처리 API 연결


### 💭 리뷰 사항 반영 


### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
