### PR TITLE
fix: 광고 감지 및 복귀 로직 에러 해결

### DIFF
--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -15,17 +15,17 @@ const handleTranscribedText =
 
     const keywordList = getAdKeywords();
     const matched = keywordList.find(({ keyword }) => text.includes(keyword));
-    const adKey = `${userId}:${channelId}`;
+    const userChannelKey = `${userId}:${channelId}`;
     const userStatus = userChannelStatus.get(userId);
 
     const isMovedChannel =
       userStatus?.prevChannelId && channelId === userStatus.prevChannelId;
 
     if (matched) {
-      if (!userIsAdPlaying.get(adKey)) {
+      if (!userIsAdPlaying.get(userChannelKey)) {
         io.to(socketId).emit("radioText", { isAd: true });
         userChannelStatus.set(userId, { prevChannelId: channelId });
-        userIsAdPlaying.set(adKey, true);
+        userIsAdPlaying.set(userChannelKey, true);
       }
 
       if (userAdEndTimers.has(userId)) {
@@ -36,7 +36,7 @@ const handleTranscribedText =
       return;
     }
 
-    if (isMovedChannel && userIsAdPlaying.get(adKey)) {
+    if (isMovedChannel && userIsAdPlaying.get(userChannelKey)) {
       if (!userAdEndTimers.has(userId)) {
         const timer = setTimeout(async () => {
           try {
@@ -45,7 +45,7 @@ const handleTranscribedText =
               io.to(socketId).emit("radioText", { isAd: false });
             }
 
-            userIsAdPlaying.set(adKey, false);
+            userIsAdPlaying.set(userChannelKey, false);
             userAdEndTimers.delete(userId);
             userChannelStatus.delete(userId);
           } catch (error) {

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -1,7 +1,7 @@
 import { getAdKeywords } from "../../cache/adKeywordCache.js";
 import { getUserByIdService } from "../../services/users/userService.js";
 
-const userIsAdPlaying = new Map();
+const isAdPlaying = new Map();
 const userAdEndTimers = new Map();
 const userChannelStatus = new Map();
 
@@ -22,10 +22,10 @@ const handleTranscribedText =
       userStatus?.prevChannelId && channelId === userStatus.prevChannelId;
 
     if (matched) {
-      if (!userIsAdPlaying.get(userChannelKey)) {
+      if (!isAdPlaying.get(userChannelKey)) {
         io.to(socketId).emit("radioText", { isAd: true });
         userChannelStatus.set(userId, { prevChannelId: channelId });
-        userIsAdPlaying.set(userChannelKey, true);
+        isAdPlaying.set(userChannelKey, true);
       }
 
       if (userAdEndTimers.has(userId)) {
@@ -36,7 +36,7 @@ const handleTranscribedText =
       return;
     }
 
-    if (isMovedChannel && userIsAdPlaying.get(userChannelKey)) {
+    if (isMovedChannel && isAdPlaying.get(userChannelKey)) {
       if (!userAdEndTimers.has(userId)) {
         const timer = setTimeout(async () => {
           try {
@@ -45,7 +45,7 @@ const handleTranscribedText =
               io.to(socketId).emit("radioText", { isAd: false });
             }
 
-            userIsAdPlaying.set(userChannelKey, false);
+            isAdPlaying.set(userChannelKey, false);
             userAdEndTimers.delete(userId);
             userChannelStatus.delete(userId);
           } catch (error) {

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -1,13 +1,13 @@
 import { getAdKeywords } from "../../cache/adKeywordCache.js";
 import { getUserByIdService } from "../../services/users/userService.js";
 
-let isAdPlaying = false;
+const userIsAdPlaying = new Map();
 const userAdEndTimers = new Map();
+const userChannelStatus = new Map();
 
 const handleTranscribedText =
   (io, userMap) =>
-  async ({ text, userId }) => {
-    console.log("[Whisper] Received text:", text);
+  async ({ text, userId, channelId }) => {
     const socketId = userMap.get(userId);
     if (!socketId) {
       return;
@@ -15,11 +15,17 @@ const handleTranscribedText =
 
     const keywordList = getAdKeywords();
     const matched = keywordList.find(({ keyword }) => text.includes(keyword));
+    const adKey = `${userId}:${channelId}`;
+    const userStatus = userChannelStatus.get(userId);
+
+    const isMovedChannel =
+      userStatus?.prevChannelId && channelId === userStatus.prevChannelId;
 
     if (matched) {
-      if (!isAdPlaying) {
+      if (!userIsAdPlaying.get(adKey)) {
         io.to(socketId).emit("radioText", { isAd: true });
-        isAdPlaying = true;
+        userChannelStatus.set(userId, { prevChannelId: channelId });
+        userIsAdPlaying.set(adKey, true);
       }
 
       if (userAdEndTimers.has(userId)) {
@@ -30,23 +36,25 @@ const handleTranscribedText =
       return;
     }
 
-    if (isAdPlaying && !userAdEndTimers.has(userId)) {
-      const timer = setTimeout(async () => {
-        try {
-          const user = await getUserByIdService(userId);
+    if (isMovedChannel && userIsAdPlaying.get(adKey)) {
+      if (!userAdEndTimers.has(userId)) {
+        const timer = setTimeout(async () => {
+          try {
+            const user = await getUserByIdService(userId);
+            if (user.isReturnChannel) {
+              io.to(socketId).emit("radioText", { isAd: false });
+            }
 
-          if (user.isReturnChannel) {
-            io.to(socketId).emit("radioText", { isAd: false });
+            userIsAdPlaying.set(adKey, false);
+            userAdEndTimers.delete(userId);
+            userChannelStatus.delete(userId);
+          } catch (error) {
+            console.error("Failed to fetch user information", error);
           }
+        }, 5000);
 
-          isAdPlaying = false;
-          userAdEndTimers.delete(userId);
-        } catch (error) {
-          console.error("Failed to fetch user information", error);
-        }
-      }, 5000);
-
-      userAdEndTimers.set(userId, timer);
+        userAdEndTimers.set(userId, timer);
+      }
     }
   };
 

--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -51,7 +51,7 @@ const handleTranscribedText =
           } catch (error) {
             console.error("Failed to fetch user information", error);
           }
-        }, 5000);
+        }, 15000);
 
         userAdEndTimers.set(userId, timer);
       }

--- a/src/utils/sendStreamingUrlToWhisper.js
+++ b/src/utils/sendStreamingUrlToWhisper.js
@@ -1,11 +1,12 @@
 import axios from "axios";
 
-export const sendStreamingUrlToWhisper = async (url, userId) => {
+export const sendStreamingUrlToWhisper = async (url, userId, channelId) => {
   try {
     // TODO: Whisper 서버 배포 시 주소 변경
     await axios.post("http://localhost:5000/transcribe", {
       url,
       userId,
+      channelId,
     });
   } catch (error) {
     console.error("❌ Whisper 서버 요청 실패", error?.message);


### PR DESCRIPTION
### ✨ 이슈 번호

- #60

### 📌 설명

- 사용자가 A 채널에서 광고가 감지되어 B 채널로 이동한 후에도 A 채널의 광고 종료 여부를 감지하여, 설정에 따라 A로 복귀하는 로직을 구현했습니다.
- 그러나, A 채널에서 광고 키워드가 또 감지되면 **다시 C 채널로 이동하는 문제가 발생**하였습니다.
- 동시에 B 채널에서 텍스트 감지를 하지 않아야 하는데도 Whisper가 B 채널에서 들어온 텍스트를 처리하는 문제가 존재해 이를 해결하고자 합니다.

### 📃 작업 사항

- [x] 사용자의 이전 채널과 현재 채널 상태를 명확히 분리해서 저장할 수 있도록 수정
- [x] A 채널에서 광고가 끝난 경우에만 복귀할 수 있도록 타이머 기반 복귀 로직 수정
- [x] A 채널에서 광고 키워드가 다시 감지돼도 불필요하게 다른 채널(C)로 넘어가지 않도록 중복 이동 방지 구현
- [x] Whisper에서 전달받는 `text`에 대해 `channelId` 기반으로 명확히 판별되도록 수정

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
