### PR TITLE
fix: 광고 제보 문구가 null일 경우 유효성 검사 통과하도록 수정

### DIFF
--- a/src/validators/reportValidator.js
+++ b/src/validators/reportValidator.js
@@ -6,7 +6,7 @@ export const validateReportBody = (req, res, next) => {
   const isInvalidFormat =
     typeof userId !== "number" ||
     typeof isAd !== "boolean" ||
-    typeof detectedAdPhrase !== "string" ||
+    !(typeof detectedAdPhrase === "string" || detectedAdPhrase === null) ||
     typeof channelId !== "number";
 
   if (isInvalidFormat) {

--- a/src/validators/reportValidator.js
+++ b/src/validators/reportValidator.js
@@ -3,13 +3,13 @@ import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
 export const validateReportBody = (req, res, next) => {
   const { userId, isAd, detectedAdPhrase, channelId } = req.body || {};
 
-  const isInvalidFormat =
-    typeof userId !== "number" ||
-    typeof isAd !== "boolean" ||
-    !(typeof detectedAdPhrase === "string" || detectedAdPhrase === null) ||
-    typeof channelId !== "number";
+  const isValidFormat =
+    typeof userId === "number" &&
+    typeof isAd === "boolean" &&
+    (typeof detectedAdPhrase === "string" || detectedAdPhrase === null) &&
+    typeof channelId === "number";
 
-  if (isInvalidFormat) {
+  if (!isValidFormat) {
     return res.status(HTTP_STATUS.BAD_REQUEST).json({
       status: HTTP_STATUS.BAD_REQUEST,
       error: MESSAGES.ERROR.INVALID_FORMAT,


### PR DESCRIPTION
### ✨ 이슈 번호

- #64 

### 📌 설명

* 광고 제보 API에서 detectedAdPhrase는 선택 입력 항목으로, 프론트엔드에서 빈 문자열일 경우 null로 전달되도록 되어 있습니다.
* 기존 유효성 검사에서는 detectedAdPhrase가 반드시 문자열이어야 통과하도록 되어 있어, null일 경우에도 400 Bad Request가 발생했습니다.
* 이를 수정하여 detectedAdPhrase가 null이거나 문자열일 경우 모두 유효한 값으로 처리되도록 했습니다.

### 📃 작업 사항

* validateReportBody 미들웨어에서 detectedAdPhrase의 타입 검사 조건 수정
  - [x] null 값도 유효한 입력으로 인정되도록 조건 추가

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
