### PR TITLE
feat: 사용자 광고 감지 채널 설정값 저장 및 반환 로직 구현

### DIFF
--- a/src/controllers/users/userSettingController.js
+++ b/src/controllers/users/userSettingController.js
@@ -26,6 +26,18 @@ export const updateUserSettingsById = async (req, res, next) => {
       }
     }
 
+    const { adRedirectChannelId } = req.body;
+    if (adRedirectChannelId != undefined) {
+      const isValidChannelId = Number.isInteger(adRedirectChannelId);
+      if (!isValidChannelId) {
+        return res.status(HTTP_STATUS.BAD_REQUEST).json({
+          status: HTTP_STATUS.BAD_REQUEST,
+          error: MESSAGES.ERROR.INVALID_FORMAT,
+        });
+      }
+      updateFields["ad_redirect_channel_id"] = adRedirectChannelId;
+    }
+
     if (Object.keys(updateFields).length === 0) {
       return res.status(HTTP_STATUS.BAD_REQUEST).json({
         status: HTTP_STATUS.BAD_REQUEST,

--- a/src/controllers/users/userSettingController.js
+++ b/src/controllers/users/userSettingController.js
@@ -3,6 +3,13 @@ import { getUserByIdService } from "../../services/users/userService.js";
 import { updateUserSettingsByIdService } from "../../services/users/userSettingService.js";
 import { stringToSnakeCase } from "../../utils/caseConverter.js";
 
+const respondInvalidFormat = (res) => {
+  return res.status(HTTP_STATUS.BAD_REQUEST).json({
+    status: HTTP_STATUS.BAD_REQUEST,
+    error: MESSAGES.ERROR.INVALID_FORMAT,
+  });
+};
+
 export const updateUserSettingsById = async (req, res, next) => {
   try {
     const { userId } = req.params;
@@ -13,36 +20,28 @@ export const updateUserSettingsById = async (req, res, next) => {
     ]);
 
     const updateFields = {};
+
     for (const [reqKey, dbKey] of settingFields) {
       const value = req.body?.[reqKey];
       if (value !== undefined) {
         if (typeof value !== "boolean") {
-          return res.status(HTTP_STATUS.BAD_REQUEST).json({
-            status: HTTP_STATUS.BAD_REQUEST,
-            error: MESSAGES.ERROR.INVALID_FORMAT,
-          });
+          return respondInvalidFormat(res);
         }
         updateFields[dbKey] = value;
       }
     }
 
     const { adRedirectChannelId } = req.body;
-    if (adRedirectChannelId != undefined) {
+    if (adRedirectChannelId !== undefined) {
       const isValidChannelId = Number.isInteger(adRedirectChannelId);
       if (!isValidChannelId) {
-        return res.status(HTTP_STATUS.BAD_REQUEST).json({
-          status: HTTP_STATUS.BAD_REQUEST,
-          error: MESSAGES.ERROR.INVALID_FORMAT,
-        });
+        return respondInvalidFormat(res);
       }
       updateFields["ad_redirect_channel_id"] = adRedirectChannelId;
     }
 
     if (Object.keys(updateFields).length === 0) {
-      return res.status(HTTP_STATUS.BAD_REQUEST).json({
-        status: HTTP_STATUS.BAD_REQUEST,
-        error: MESSAGES.ERROR.INVALID_FORMAT,
-      });
+      return respondInvalidFormat(res);
     }
 
     const user = await getUserByIdService(Number(userId));
@@ -57,6 +56,7 @@ export const updateUserSettingsById = async (req, res, next) => {
       Number(userId),
       updateFields
     );
+
     res.status(HTTP_STATUS.OK).json(message);
   } catch (error) {
     next(error);

--- a/src/controllers/users/userSettingController.js
+++ b/src/controllers/users/userSettingController.js
@@ -33,7 +33,8 @@ export const updateUserSettingsById = async (req, res, next) => {
 
     const { adRedirectChannelId } = req.body;
     if (adRedirectChannelId !== undefined) {
-      const isValidChannelId = Number.isInteger(adRedirectChannelId);
+      const isValidChannelId =
+        adRedirectChannelId === null || Number.isInteger(adRedirectChannelId);
       if (!isValidChannelId) {
         return respondInvalidFormat(res);
       }

--- a/src/services/users/userService.js
+++ b/src/services/users/userService.js
@@ -27,6 +27,7 @@ export const getUserByIdService = async (userId) => {
       id,
       is_ad_detect,
       is_return_channel,
+      ad_redirect_channel_id,
       created_at,
       interest_channels (
         channel_id
@@ -50,6 +51,7 @@ export const getUserByIdService = async (userId) => {
   return {
     ...camelData,
     userId: camelData.id,
+    adRedirectChannelId: camelData.adRedirectChannelId,
     interestChannels: camelData.interestChannels.map((item) => ({
       channelId: item.channelId,
     })),

--- a/src/services/users/userService.js
+++ b/src/services/users/userService.js
@@ -51,7 +51,6 @@ export const getUserByIdService = async (userId) => {
   return {
     ...camelData,
     userId: camelData.id,
-    adRedirectChannelId: camelData.adRedirectChannelId,
     interestChannels: camelData.interestChannels.map((item) => ({
       channelId: item.channelId,
     })),


### PR DESCRIPTION
### ✨ 이슈 번호

- #68 

### 📌 설명

- 사용자가 광고 감지 기능을 사용할 때, 광고 발생 시 자동으로 전환될 채널을 설정할 수 있도록 `adRedirectChannelId` 값을 저장하고 조회하는 기능을 추가 작업한 Pulll Request입니다.


### 📃 작업 사항

- [x] 사용자 설정)에서 adRedirectChannelId 처리 로직 추가
- [x] adRedirectChannelId가 정수인지 검증하는 유효성 검사 추가
- [x] Supabase users 테이블에 ad_redirect_channel_id 필드로 저장되도록 설정
- [x] 사용자 조회에서 ad_redirect_channel_id 값 포함하도록 수정
- [x] 조회 결과 adRedirectChannelId 응답에 포함
- [x] Supabase `users` 테이블에 `ad_redirect_channel_id` 값이 올바르게 저장되는지 확인
- [x] GET 요청 시 `adRedirectChannelId` 값이 응답에 포함되는지 확인
- [x] 중복된 BAD_REQUEST 응답 처리 로직 `respondInvalidFormat` 함수로 분리

### 💡 참고 사항 

**🔗PUT 요청 결과**

![image](https://github.com/user-attachments/assets/cb89b6f8-da80-444f-8010-d942e697daf8)

**🔗DB 저장 결과 확인**

![image](https://github.com/user-attachments/assets/1650b516-a339-4d5c-b22b-9ca2c63fc09a)


### 💭 리뷰 사항 반영
- [x] `adRedirectChannelId`가 `null`로 전달될 수 있는 경우를 고려해 조건문 수정
  - [x] `adRedirectChannelId === null || Number.isInteger(adRedirectChannelId)` 조건으로 분리 처리
  - [x] 사용자 선택 해제(`null`)도 유효한 입력으로 허용되도록 개선
  
### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
