### PR TITLE
chore: 소켓 서버 CORS 설정 추가

### DIFF
--- a/src/constants/env.js
+++ b/src/constants/env.js
@@ -1,0 +1,4 @@
+import dotenv from "dotenv";
+dotenv.config();
+
+export const allowedOrigin = process.env.FRONT_API_URL.replace(/\/$/, "");

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ import cors from "cors";
 import dotenv from "dotenv";
 import express from "express";
 
+import { allowedOrigin } from "./constants/env.js";
 import { loadAdKeywords } from "./init/loadAdKeywords.js";
 import { errorHandler } from "./middlewares/errorHandler.js";
 import adKeywordRoutes from "./routes/ad-keywords/index.js";
@@ -18,7 +19,6 @@ dotenv.config();
 const app = express();
 app.use(express.json());
 
-const allowedOrigin = process.env.FRONT_API_URL.replace(/\/$/, "");
 app.use(
   cors({
     origin: allowedOrigin,

--- a/src/sockets/index.js
+++ b/src/sockets/index.js
@@ -6,10 +6,12 @@ import registerWhisperHandlers from "./handlers/whisperHandler.js";
 const userMap = new Map();
 
 export const initSocket = (server) => {
+  const allowedOrigin = process.env.FRONT_API_URL.replace(/\/$/, "");
+
   const io = new Server(server, {
     cors: {
-      // TODO: 서버 배포 시 origin 업데이트
-      origin: "*",
+      origin: allowedOrigin,
+      methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     },
   });
 

--- a/src/sockets/index.js
+++ b/src/sockets/index.js
@@ -1,13 +1,12 @@
 import { Server } from "socket.io";
 
+import { allowedOrigin } from "../constants/env.js";
 import registerClientHandlers from "./handlers/clientHandler.js";
 import registerWhisperHandlers from "./handlers/whisperHandler.js";
 
 const userMap = new Map();
 
 export const initSocket = (server) => {
-  const allowedOrigin = process.env.FRONT_API_URL.replace(/\/$/, "");
-
   const io = new Server(server, {
     cors: {
       origin: allowedOrigin,


### PR DESCRIPTION
### ✨ 이슈 번호 

- #76 

### 📌 설명

- 프론트엔드(https://www.radio-premium.monster)에서 백엔드(https://backend.radio-premium.monster)의 소켓 서버로 연결 시도 시, CORS 정책에 의해 차단되는 문제를 해결한 Pull Request입니다.
```
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```
- 이를 해결하기 위해, 소켓 서버 인스턴스 생성 시 cors 옵션을 명시적으로 설정하여 해당 출처의 요청을 허용하도록 수정했습니다.

### 📃 작업 사항

- [x] 환경 변수(`FRONT_API_URL`)에서 origin 값 가져오도록 설정
- [x] URL 끝의 `/` 제거 처리 (정규표현식 사용)
- [x] `Server` 인스턴스에 `cors` 옵션으로 `origin`과 `methods` 명시
  - origin: `.env`에서 정의된 프론트엔드 도메인
  - methods: `["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]` 설정
- [x] 기존 `origin: "*"` 설정 제거


### 💭 리뷰 사항 반영 


### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
