### PR TITLE
feat: 머신러닝 + 키워드 기반 광고 탐지 로직 개선

### DIFF
--- a/src/sockets/handlers/transcribedTextHandler.js
+++ b/src/sockets/handlers/transcribedTextHandler.js
@@ -7,21 +7,28 @@ const userChannelStatus = new Map();
 
 const handleTranscribedText =
   (io, userMap) =>
-  async ({ text, userId, channelId }) => {
+  async ({ text, userId, channelId, isAd, confidence }) => {
     const socketId = userMap.get(userId);
     if (!socketId) {
       return;
     }
 
-    const keywordList = getAdKeywords();
-    const matched = keywordList.find(({ keyword }) => text.includes(keyword));
+    const needsKeywordValidation = !isAd && confidence < 0.75;
+    if (needsKeywordValidation) {
+      const keywordList = getAdKeywords();
+      const matched = keywordList.find(({ keyword }) => text.includes(keyword));
+      if (matched) {
+        isAd = true;
+      }
+    }
+
     const userChannelKey = `${userId}:${channelId}`;
     const userStatus = userChannelStatus.get(userId);
 
     const isMovedChannel =
       userStatus?.prevChannelId && channelId === userStatus.prevChannelId;
 
-    if (matched) {
+    if (isAd) {
       if (!isAdPlaying.get(userChannelKey)) {
         io.to(socketId).emit("radioText", { isAd: true });
         userChannelStatus.set(userId, { prevChannelId: channelId });


### PR DESCRIPTION
### ✨ 이슈 번호

- #78

### 📌 설명

- 기존 키워드 포함 여부만으로 광고 여부를 판단하는 로직에서 머신러닝 기반 정밀한 로직으로 개선하여 작성한 Pull Request입니다.
- Whisper 서버에서 머신러닝을 기반으로 광고 여부(`isAd`)가 판단되어 전달되며,
광고가 아닌 일반 멘트의 경우 신뢰도(`confidence`) 75% 미만이면
기존 키워드 기반 광고 탐지 방식으로 추가 비교합니다.

### 📃 작업 사항

- [x] `Whisper` 서버에서 전달된 `isAd`, `confidence` 값을 수신하는 매개변수 추가
- [x] 광고 멘트(`isAd`)일 경우 광고 처리 로직 실행
- [x] 일반 멘트 신뢰도 75% 미만일 경우 키워드 기반 광고 탐지 적용

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
