### PR TITLE
refactor: 에러 응답 유틸 함수 분리 및 중복 코드 제거

### DIFF
--- a/src/controllers/radio-channels/radioChannelController.js
+++ b/src/controllers/radio-channels/radioChannelController.js
@@ -4,6 +4,7 @@ import {
   getRadioChannelByIdService,
   getRandomNoAdChannelService,
 } from "../../services/radio-channels/radioChannelService.js";
+import { respondNotFound } from "../../utils/errorResponse.js";
 
 export const getRadioChannelList = async (_req, res, next) => {
   try {
@@ -28,10 +29,7 @@ export const getRadioChannelById = async (req, res, next) => {
     );
 
     if (!channel) {
-      return res.status(HTTP_STATUS.NOT_FOUND).json({
-        status: HTTP_STATUS.NOT_FOUND,
-        error: MESSAGES.ERROR.CHANNEL_NOT_FOUND,
-      });
+      return respondNotFound(res, MESSAGES.ERROR.CHANNEL_NOT_FOUND);
     }
 
     res.status(HTTP_STATUS.OK).json(channel);
@@ -45,10 +43,7 @@ export const getRandomNoAdChannel = async (_req, res, next) => {
     const randomChannel = await getRandomNoAdChannelService();
 
     if (!randomChannel) {
-      return res.status(HTTP_STATUS.NOT_FOUND).json({
-        status: HTTP_STATUS.NOT_FOUND,
-        error: MESSAGES.ERROR.CHANNEL_NOT_FOUND,
-      });
+      return respondNotFound(res, MESSAGES.ERROR.CHANNEL_NOT_FOUND);
     }
 
     return res.status(HTTP_STATUS.OK).json(randomChannel);

--- a/src/controllers/users/userController.js
+++ b/src/controllers/users/userController.js
@@ -1,9 +1,13 @@
-import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import {
   createUserService,
   getUserByIdService,
 } from "../../services/users/userService.js";
 import { stringToSnakeCase } from "../../utils/caseConverter.js";
+import {
+  respondInvalidFormat,
+  respondNotFound,
+} from "../../utils/errorResponse.js";
+import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
 
 export const createUser = async (req, res, next) => {
   try {
@@ -18,10 +22,7 @@ export const createUser = async (req, res, next) => {
       const value = req.body?.[reqKey];
       if (value !== undefined) {
         if (typeof value !== "boolean") {
-          return res.status(HTTP_STATUS.BAD_REQUEST).json({
-            status: HTTP_STATUS.BAD_REQUEST,
-            error: MESSAGES.ERROR.INVALID_FORMAT,
-          });
+          return respondInvalidFormat(res);
         }
         insertFields[dbKey] = value;
       }
@@ -40,10 +41,7 @@ export const getUserById = async (req, res, next) => {
     const user = await getUserByIdService(Number(userId));
 
     if (!user) {
-      return res.status(HTTP_STATUS.NOT_FOUND).json({
-        status: HTTP_STATUS.NOT_FOUND,
-        error: MESSAGES.ERROR.USER_NOT_FOUND,
-      });
+      return respondNotFound(res, MESSAGES.ERROR.USER_NOT_FOUND);
     }
 
     res.status(HTTP_STATUS.OK).json(user);

--- a/src/controllers/users/userInterestChannelController.js
+++ b/src/controllers/users/userInterestChannelController.js
@@ -1,10 +1,11 @@
-import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
+import { HTTP_STATUS } from "../../constants/index.js";
 import {
   createInterestChannelService,
   getInterestChannelByIdService,
   updateInterestChannelsService,
   deleteInterestChannelService,
 } from "../../services/users/userInterestChannelService.js";
+import { respondInvalidFormat } from "../../utils/errorResponse.js";
 
 export const createInterestChannel = async (req, res, next) => {
   try {
@@ -12,10 +13,7 @@ export const createInterestChannel = async (req, res, next) => {
     const { channelId } = req.body;
 
     if (typeof channelId !== "number") {
-      return res.status(HTTP_STATUS.BAD_REQUEST).json({
-        status: HTTP_STATUS.BAD_REQUEST,
-        error: MESSAGES.ERROR.INVALID_FORMAT,
-      });
+      return respondInvalidFormat(res);
     }
 
     const message = await createInterestChannelService(
@@ -46,10 +44,7 @@ export const updateInterestChannels = async (req, res, next) => {
     const { channelIds } = req.body;
 
     if (!Array.isArray(channelIds)) {
-      return res.status(HTTP_STATUS.BAD_REQUEST).json({
-        status: HTTP_STATUS.BAD_REQUEST,
-        error: MESSAGES.ERROR.INVALID_FORMAT,
-      });
+      return respondInvalidFormat(res);
     }
 
     const result = await updateInterestChannelsService(
@@ -68,10 +63,7 @@ export const deleteInterestChannel = async (req, res, next) => {
     const { channelId } = req.body;
 
     if (typeof channelId !== "number") {
-      return res.status(HTTP_STATUS.BAD_REQUEST).json({
-        status: HTTP_STATUS.BAD_REQUEST,
-        error: MESSAGES.ERROR.INVALID_FORMAT,
-      });
+      return respondInvalidFormat(res);
     }
 
     const message = await deleteInterestChannelService(

--- a/src/controllers/users/userSettingController.js
+++ b/src/controllers/users/userSettingController.js
@@ -2,13 +2,10 @@ import { HTTP_STATUS, MESSAGES } from "../../constants/index.js";
 import { getUserByIdService } from "../../services/users/userService.js";
 import { updateUserSettingsByIdService } from "../../services/users/userSettingService.js";
 import { stringToSnakeCase } from "../../utils/caseConverter.js";
-
-const respondInvalidFormat = (res) => {
-  return res.status(HTTP_STATUS.BAD_REQUEST).json({
-    status: HTTP_STATUS.BAD_REQUEST,
-    error: MESSAGES.ERROR.INVALID_FORMAT,
-  });
-};
+import {
+  respondInvalidFormat,
+  respondNotFound,
+} from "../../utils/errorResponse.js";
 
 export const updateUserSettingsById = async (req, res, next) => {
   try {
@@ -47,10 +44,7 @@ export const updateUserSettingsById = async (req, res, next) => {
 
     const user = await getUserByIdService(Number(userId));
     if (!user) {
-      return res.status(HTTP_STATUS.NOT_FOUND).json({
-        status: HTTP_STATUS.NOT_FOUND,
-        error: MESSAGES.ERROR.USER_NOT_FOUND,
-      });
+      return respondNotFound(res, MESSAGES.ERROR.USER_NOT_FOUND);
     }
 
     const message = await updateUserSettingsByIdService(

--- a/src/utils/errorResponse.js
+++ b/src/utils/errorResponse.js
@@ -1,0 +1,15 @@
+import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
+
+export const respondInvalidFormat = (res) => {
+  return res.status(HTTP_STATUS.BAD_REQUEST).json({
+    status: HTTP_STATUS.BAD_REQUEST,
+    error: MESSAGES.ERROR.INVALID_FORMAT,
+  });
+};
+
+export const respondNotFound = (res, message) => {
+  return res.status(HTTP_STATUS.NOT_FOUND).json({
+    status: HTTP_STATUS.NOT_FOUND,
+    error: message,
+  });
+};

--- a/src/utils/errorResponse.js
+++ b/src/utils/errorResponse.js
@@ -1,15 +1,17 @@
 import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
 
+const respondWithError = (res, status, message) => {
+  return res.status(status).json({ status, error: message });
+};
+
 export const respondInvalidFormat = (res) => {
-  return res.status(HTTP_STATUS.BAD_REQUEST).json({
-    status: HTTP_STATUS.BAD_REQUEST,
-    error: MESSAGES.ERROR.INVALID_FORMAT,
-  });
+  return respondWithError(
+    res,
+    HTTP_STATUS.BAD_REQUEST,
+    MESSAGES.ERROR.INVALID_FORMAT
+  );
 };
 
 export const respondNotFound = (res, message) => {
-  return res.status(HTTP_STATUS.NOT_FOUND).json({
-    status: HTTP_STATUS.NOT_FOUND,
-    error: message,
-  });
+  return respondWithError(res, HTTP_STATUS.NOT_FOUND, message);
 };

--- a/src/validators/channelValidator.js
+++ b/src/validators/channelValidator.js
@@ -1,13 +1,10 @@
-import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
+import { respondInvalidFormat } from "../../utils/errorResponse.js";
 
 export const validateChannelId = (req, res, next) => {
   const { channelId } = req.params;
 
   if (Number.isNaN(Number(channelId))) {
-    return res.status(HTTP_STATUS.BAD_REQUEST).json({
-      status: HTTP_STATUS.BAD_REQUEST,
-      error: MESSAGES.ERROR.INVALID_FORMAT,
-    });
+    return respondInvalidFormat(res);
   }
 
   next();

--- a/src/validators/reportValidator.js
+++ b/src/validators/reportValidator.js
@@ -1,4 +1,4 @@
-import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
+import { respondInvalidFormat } from "../../utils/errorResponse.js";
 
 export const validateReportBody = (req, res, next) => {
   const { userId, isAd, detectedAdPhrase, channelId } = req.body || {};
@@ -10,10 +10,7 @@ export const validateReportBody = (req, res, next) => {
     typeof channelId === "number";
 
   if (!isValidFormat) {
-    return res.status(HTTP_STATUS.BAD_REQUEST).json({
-      status: HTTP_STATUS.BAD_REQUEST,
-      error: MESSAGES.ERROR.INVALID_FORMAT,
-    });
+    return respondInvalidFormat(res);
   }
 
   next();

--- a/src/validators/userValidator.js
+++ b/src/validators/userValidator.js
@@ -1,13 +1,10 @@
-import { HTTP_STATUS, MESSAGES } from "../constants/index.js";
+import { respondInvalidFormat } from "../../utils/errorResponse.js";
 
 export const validateUserId = (req, res, next) => {
   const { userId } = req.params;
 
   if (Number.isNaN(Number(userId))) {
-    return res.status(HTTP_STATUS.BAD_REQUEST).json({
-      status: HTTP_STATUS.BAD_REQUEST,
-      error: MESSAGES.ERROR.INVALID_FORMAT,
-    });
+    return respondInvalidFormat(res);
   }
 
   next();


### PR DESCRIPTION
### ✨ 이슈 번호 

- #82 

### 📌 설명 

- 코드 전반에서 반복 사용하던 에러 응답 코드를 공통 유틸 함수(`respondInvalidFormat`, `respondNotFound`)로 분리하고, 여러 컨트롤러 및 관련 모듈에서 해당 유틸 함수를 `import` 하여 중복 코드를 제거하고, 에러 응답을 일관되게 정리한 Pull Request입니다.

### 📃 작업 사항 

- [x] `utils/errorResponse.js` 파일 생성
- [x] `respondInvalidFormat` 함수 추가
- [x] `respondNotFound` 함수 추가
- [x] 기존 중복 응답 코드 제거 및 유틸 적용

### 💭 리뷰 사항 반영 

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
